### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/Accumulation.R
+++ b/R/Accumulation.R
@@ -237,9 +237,9 @@ autoplot.AccumCurve <-
 function(object, ..., main = NULL, 
          xlab = "Sample Size", ylab = NULL, 
          ShadeColor = "grey75", alpha = 0.3, BorderColor = "red",
-         col = ggplot2::GeomLine$default_aes$colour,
-         lty = ggplot2::GeomLine$default_aes$linetype,
-         lwd = ggplot2::GeomLine$default_aes$size)
+         col = "black",
+         lty = 1,
+         lwd = 0.5)
 {  
   thePlot <- ggplot2::ggplot(as.data.frame.list(object), ggplot2::aes(x=.data$x, y=.data$y))
   if (!(is.null(object$high) | is.null(object$low))) {

--- a/R/CommunityProfile.R
+++ b/R/CommunityProfile.R
@@ -131,9 +131,9 @@ autoplot.CommunityProfile <-
   function(object, ..., main = NULL, 
            xlab = "Order of Diversity", ylab = "Diversity", 
            ShadeColor = "grey75", alpha = 0.3, BorderColor = "red",
-           col = ggplot2::GeomLine$default_aes$colour,
-           lty = ggplot2::GeomLine$default_aes$linetype,
-           lwd = ggplot2::GeomLine$default_aes$size)
+           col = "black",
+           lty = 1,
+           lwd = 0.5)
 {  
   thePlot <- ggplot2::ggplot(as.data.frame.list(object), ggplot2::aes(x=.data$x, y=.data$y))
   if (!(is.null(object$high) | is.null(object$low))) {

--- a/R/DivPart.R
+++ b/R/DivPart.R
@@ -93,8 +93,8 @@ function (x, ...)
 
 
 autoplot.DivPart <- 
-function (object, col = ggplot2::GeomRect$default_aes$fill, 
-          border = ggplot2::GeomRect$default_aes$colour, ...) 
+function (object, col = "grey35", 
+          border = NA, ...) 
 {
   thePlot <- ggplot2::ggplot() +
     ggplot2::geom_rect(ggplot2::aes(xmin=.data$xmin, ymin=.data$ymin, xmax=.data$xmax, ymax=.data$ymax), 

--- a/R/DivProfile.R
+++ b/R/DivProfile.R
@@ -219,9 +219,9 @@ function (x, ..., main = NULL, xlab = "Order of Diversity", ylab = NULL, Which =
 autoplot.DivProfile <- 
 function (object, ..., main = NULL, xlab = "Order of Diversity", ylab = NULL, Which = "All", 
           ShadeColor = "grey75", alpha = 0.3, BorderColor = "red", labels = NULL, font.label = list(size=11, face="plain"),
-          col = ggplot2::GeomLine$default_aes$colour,
-          lty = ggplot2::GeomLine$default_aes$linetype,
-          lwd = ggplot2::GeomLine$default_aes$size)
+          col = "black",
+          lty = 1,
+          lwd = 0.5)
 {
   if (Which == "All" | (Which == "Alpha" & is.null(main))) main <- "Total Alpha Diversity"
   if (Which == "All" | (Which == "Alpha" & is.null(ylab))) ylab <- expression(paste(alpha, " diversity"))

--- a/R/MCdiversity.R
+++ b/R/MCdiversity.R
@@ -20,8 +20,8 @@ function (x, ...)
 
 
 autoplot.MCdiversity <- 
-function (object, col = ggplot2::GeomCol$default_aes$fill,
-          border = ggplot2::GeomCol$default_aes$colour, ...) 
+function (object, col = "grey35",
+          border = NA, ...) 
 {
   theData <- data.frame(x=c(names(object$Communities), "", "Metacommunity"), y=c(object$Communities, 0, object$Total))
   # Factors to keep the order of bars (avoid sort by name)

--- a/R/MCentropy.R
+++ b/R/MCentropy.R
@@ -19,8 +19,8 @@ function (x, ...)
 
 
 autoplot.MCentropy <- 
-function (object, col = ggplot2::GeomCol$default_aes$fill,
-          border = ggplot2::GeomCol$default_aes$colour, ...) 
+function (object, col = "grey35",
+          border = NA, ...) 
 {
   theData <- data.frame(x=c(names(object$Communities), "", "Metacommunity"), y=c(object$Communities, 0, object$Total))
   # Factors to keep the order of bars (avoid sort by name)

--- a/R/PhyloValue.R
+++ b/R/PhyloValue.R
@@ -33,9 +33,9 @@ function (x, xlab = expression(italic("T")), ylab = NULL, main = NULL, ...)
 
 autoplot.PhyloValue <- 
 function (object, xlab = expression(italic("T")), ylab = NULL, main = NULL, 
-          col = ggplot2::GeomLine$default_aes$colour,
-          lty = ggplot2::GeomLine$default_aes$linetype,
-          lwd = ggplot2::GeomLine$default_aes$size,
+          col = "black",
+          lty = 1,
+          lwd = 0.5,
           ...) 
 {
   Entity <- ""

--- a/R/SpeciesDistribution.R
+++ b/R/SpeciesDistribution.R
@@ -371,9 +371,9 @@ function(x, ..., Distribution = NULL,
 autoplot.SpeciesDistribution <-
 function(object, ..., Distribution = NULL, 
          ylog = TRUE, main = NULL, xlab = "Rank", ylab = NULL, 
-         pch = ggplot2::GeomPoint$default_aes$shape,
-         col = ggplot2::GeomPoint$default_aes$colour,
-         cex = ggplot2::GeomPoint$default_aes$size) 
+         pch = 19,
+         col = "black",
+         cex = 1.5) 
 {
   # Eliminate zeros and sort
   Ns <- sort(object[object > 0], decreasing = TRUE)

--- a/man/Accumulation.Rd
+++ b/man/Accumulation.Rd
@@ -27,9 +27,9 @@ DivAC(Ns, q = 0, n.seq = seq_len(sum(Ns)), PCorrection="Chao2015", Unveiling="ge
 \method{autoplot}{AccumCurve}(object, ..., main = NULL, 
          xlab = "Sample Size", ylab = NULL, 
          ShadeColor = "grey75", alpha = 0.3, BorderColor = "red",
-         col = ggplot2::GeomLine$default_aes$colour,
-         lty = ggplot2::GeomLine$default_aes$linetype,
-         lwd = ggplot2::GeomLine$default_aes$size)
+         col = "black",
+         lty = 1,
+         lwd = 0.5)
 }
 \arguments{
   \item{x}{

--- a/man/CommunityProfile.Rd
+++ b/man/CommunityProfile.Rd
@@ -23,9 +23,9 @@ is.CommunityProfile(x)
 \method{autoplot}{CommunityProfile}(object, \dots, main = NULL, 
           xlab = "Order of Diversity", ylab = "Diversity",
           ShadeColor = "grey75", alpha = 0.3, BorderColor = "red",
-          col = ggplot2::GeomLine$default_aes$colour,
-          lty = ggplot2::GeomLine$default_aes$linetype,
-          lwd = ggplot2::GeomLine$default_aes$size)
+          col = "black",
+          lty = 1,
+          lwd = 0.5)
 CEnvelope(Profile, LineWidth = 2, ShadeColor = "grey75", BorderColor = "red", \dots)
 }
 \arguments{

--- a/man/DivPart.Rd
+++ b/man/DivPart.Rd
@@ -15,8 +15,8 @@ DivPart(q = 1, MC, Biased = TRUE, Correction = "Best", Tree = NULL,
   Normalize = TRUE, Z = NULL, CheckArguments = TRUE)
 is.DivPart(x)
 \method{plot}{DivPart}(x, \dots)
-\method{autoplot}{DivPart}(object, col = ggplot2::GeomRect$default_aes$fill, 
-  border = ggplot2::GeomRect$default_aes$colour, \dots)
+\method{autoplot}{DivPart}(object, col = "grey35", 
+  border = NA, \dots)
 \method{summary}{DivPart}(object, \dots)
 }
 \arguments{

--- a/man/DivProfile.Rd
+++ b/man/DivProfile.Rd
@@ -22,9 +22,9 @@ is.DivProfile(x)
 \method{autoplot}{DivProfile}(object, \dots, main = NULL, xlab = "Order of Diversity",
   ylab = NULL, Which = "All", ShadeColor = "grey75", alpha = 0.3, BorderColor = "red", 
   labels = NULL, font.label = list(size=11, face="plain"),
-  col = ggplot2::GeomLine$default_aes$colour,
-  lty = ggplot2::GeomLine$default_aes$linetype,
-  lwd = ggplot2::GeomLine$default_aes$size)
+  col = "black",
+  lty = 1,
+  lwd = 0.5)
 \method{summary}{DivProfile}(object, \dots)
 }
 \arguments{

--- a/man/MCdiversity.Rd
+++ b/man/MCdiversity.Rd
@@ -13,8 +13,8 @@
 \usage{
 is.MCdiversity(x)
 \method{plot}{MCdiversity}(x, \dots)
-\method{autoplot}{MCdiversity}(object, col = ggplot2::GeomCol$default_aes$fill,
-          border = ggplot2::GeomCol$default_aes$colour, \dots)
+\method{autoplot}{MCdiversity}(object, col = "grey35",
+          border = NA, \dots)
 \method{summary}{MCdiversity}(object, \dots)
 }
 \arguments{

--- a/man/MCentropy.Rd
+++ b/man/MCentropy.Rd
@@ -13,8 +13,8 @@
 \usage{
 is.MCentropy(x)
 \method{plot}{MCentropy}(x, \dots)
-\method{autoplot}{MCentropy}(object, col = ggplot2::GeomCol$default_aes$fill,
-          border = ggplot2::GeomCol$default_aes$colour, \dots)
+\method{autoplot}{MCentropy}(object, col = "grey35",
+          border = NA, \dots)
 \method{summary}{MCentropy}(object, \dots)
 }
 \arguments{

--- a/man/PhyloValue.Rd
+++ b/man/PhyloValue.Rd
@@ -13,9 +13,9 @@
 \usage{
 is.PhyloValue(x)
 \method{autoplot}{PhyloValue}(object, xlab = expression(italic("T")), ylab = NULL, main = NULL,
-          col = ggplot2::GeomLine$default_aes$colour,
-          lty = ggplot2::GeomLine$default_aes$linetype,
-          lwd = ggplot2::GeomLine$default_aes$size,
+          col = "black",
+          lty = 1,
+          lwd = 0.5,
           \dots)
 \method{plot}{PhyloValue}(x, xlab = expression(italic("T")), ylab = NULL, main = NULL, \dots)
 \method{summary}{PhyloValue}(object, \dots)

--- a/man/SpeciesDistribution.Rd
+++ b/man/SpeciesDistribution.Rd
@@ -32,9 +32,9 @@ as.SpeciesDistribution(x, \dots)
 \method{as.SpeciesDistribution}{numeric}(x, \dots)
 \method{autoplot}{SpeciesDistribution}(object, \dots, Distribution = NULL, 
          ylog = TRUE, main = NULL, xlab = "Rank", ylab = NULL, 
-         pch = ggplot2::GeomPoint$default_aes$shape,
-         col = ggplot2::GeomPoint$default_aes$colour,
-         cex = ggplot2::GeomPoint$default_aes$size) 
+         pch = 19,
+         col = "black",
+         cex = 1.5) 
 \method{plot}{SpeciesDistribution}(x, \dots, Distribution = NULL, 
          type = "b", log = "y", main = NULL, xlab = "Rank", ylab = NULL)
 is.SpeciesDistribution(x)


### PR DESCRIPTION
Hi there,

Hi there,

Apologies for not posting an issue first; this is the same problem/resolution proposal as in https://github.com/EricMarcon/divent/pull/2.

The ggplot2 package is planning an update for around may 2025 and a reverse dependency test (https://github.com/tidyverse/ggplot2/pull/6287) has shown that the next version of ggplot2 is incompatible with the entropart package.
This PR makes a few changes that fixes compatibility, which you can test yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`).
In the new version the `default_aes` fields are dynamic instead of static, which violates some assumptions in entropart.

Best,
Teun